### PR TITLE
Add support for item OBJ models

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,49 @@ map_Kd MODID:blocks/test
 ```
 
 And that's basically it, your block show now render your OBJ model! **(Note: It is recommended to scale the model before exporting it due to the size it will be rendered as)**
+
+
+### Using OBJ models for items
+
+Creating items using OBJ models is somewhat different. Firstly, the item model itself must be a `.obj-json` file, formatted as JSON, placed within the models/ path.
+
+The structure of this item model is similar to that of vanilla JSON model files, except that the parent points to a OBJ model like so:
+
+```
+// Example .obj-json file
+
+{
+    "parent": "MODID:item/test.obj",
+    "display": {
+        "head": {
+            "rotation": [0, 0, 0],
+            "translation": [0, 0, 0],
+            "scale": [1, 1, 1]
+        },
+        "firstperson_righthand": {
+            "rotation": [0, 0, 0],
+            "translation": [0, 0, 0],
+            "scale": [1, 1, 1]
+        },
+        "firstperson_lefthand": {
+            "rotation": [0, 0, 0],
+            "translation": [0, 0, 0],
+            "scale": [1, 1, 1]
+        },
+        "gui": {
+            "rotation": [0, 0, 0],
+            "translation": [0, 0, 0],
+            "scale": [1, 1, 1]
+        },
+        "fixed": {
+            "rotation": [0, 0, 0],
+            "translation": [0, 0, 0],
+            "scale": [1, 1, 1]
+        }
+    }
+}
+```
+Note that the parent of a `.obj-json` model must be a OBJ model, and normal `.json` models can not
+use a `.obj-json` model as its parent.
+
+So far, only vanilla model transformations are supported using this model format.

--- a/README.md
+++ b/README.md
@@ -66,13 +66,9 @@ And that's basically it, your block show now render your OBJ model! **(Note: It 
 
 ### Using OBJ models for items
 
-Creating items using OBJ models is somewhat different. Firstly, the item model itself must be a `.obj-json` file, formatted as JSON, placed within the models/ path.
-
-The structure of this item model is similar to that of vanilla JSON model files, except that the parent points to a OBJ model like so:
+JSON-formatted vanilla item models placed in the `models/item` folder can also specify your OBJ model as its "parent" model, similar to blockstates:
 
 ```
-// Example .obj-json file
-
 {
     "parent": "MODID:item/test.obj",
     "display": {
@@ -104,7 +100,6 @@ The structure of this item model is similar to that of vanilla JSON model files,
     }
 }
 ```
-Note that the parent of a `.obj-json` model must be a OBJ model, and normal `.json` models can not
-use a `.obj-json` model as its parent.
+And your item should now render the OBJ model with the proper transformations specified in its model file.
 
-So far, only vanilla model transformations are supported using this model format.
+So far, only vanilla model transformations are supported by FOML.

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,6 @@ loader_version = 0.4.8+build.159
 fabric_version = 0.3.0+build.207
 javagl_version = 0.3.0
 
-mod_version = 1.0.0
+mod_version = 1.1.0
 mod_group = com.github.NerdHubMC
 mod_name = FOML

--- a/src/main/java/nerdhub/foml/FOML.java
+++ b/src/main/java/nerdhub/foml/FOML.java
@@ -1,6 +1,6 @@
 package nerdhub.foml;
 
-import nerdhub.foml.obj.JsonOBJLoader;
+import nerdhub.foml.obj.ItemOBJLoader;
 import nerdhub.foml.obj.OBJLoader;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.model.ModelLoadingRegistry;
@@ -14,6 +14,6 @@ public class FOML implements ClientModInitializer {
     @Override
     public void onInitializeClient() {
         ModelLoadingRegistry.INSTANCE.registerResourceProvider(OBJLoader.INSTANCE);
-        ModelLoadingRegistry.INSTANCE.registerVariantProvider(JsonOBJLoader.INSTANCE);
+        ModelLoadingRegistry.INSTANCE.registerVariantProvider(ItemOBJLoader.INSTANCE);
     }
 }

--- a/src/main/java/nerdhub/foml/FOML.java
+++ b/src/main/java/nerdhub/foml/FOML.java
@@ -14,6 +14,6 @@ public class FOML implements ClientModInitializer {
     @Override
     public void onInitializeClient() {
         ModelLoadingRegistry.INSTANCE.registerResourceProvider(OBJLoader.INSTANCE);
-        ModelLoadingRegistry.INSTANCE.registerResourceProvider(JsonOBJLoader.INSTANCE);
+        ModelLoadingRegistry.INSTANCE.registerVariantProvider(JsonOBJLoader.INSTANCE);
     }
 }

--- a/src/main/java/nerdhub/foml/FOML.java
+++ b/src/main/java/nerdhub/foml/FOML.java
@@ -1,5 +1,6 @@
 package nerdhub.foml;
 
+import nerdhub.foml.obj.JsonOBJLoader;
 import nerdhub.foml.obj.OBJLoader;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.model.ModelLoadingRegistry;
@@ -7,12 +8,12 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 public class FOML implements ClientModInitializer {
-
     public static final String MODID = "foml";
     public static Logger LOGGER = LogManager.getLogger("FOML");
 
     @Override
     public void onInitializeClient() {
         ModelLoadingRegistry.INSTANCE.registerResourceProvider(OBJLoader.INSTANCE);
+        ModelLoadingRegistry.INSTANCE.registerResourceProvider(JsonOBJLoader.INSTANCE);
     }
 }

--- a/src/main/java/nerdhub/foml/obj/ItemOBJLoader.java
+++ b/src/main/java/nerdhub/foml/obj/ItemOBJLoader.java
@@ -18,23 +18,21 @@ import net.minecraft.resource.ResourceManager;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.JsonHelper;
 
-import java.io.FileNotFoundException;
-import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.util.function.Function;
 
 /***
- *  JsonOBJLoader
+ *  ItemOBJLoader
  *  Child class of the OBJ loader that loads basic item OBJ models with JSON model transformations.
  *
  *  Created by jard at 2:27 AM on September 22, 2019.
  ***/
-public class JsonOBJLoader implements ModelVariantProvider, Function<ResourceManager, ModelVariantProvider> {
-    public static JsonOBJLoader INSTANCE = new JsonOBJLoader ();
+public class ItemOBJLoader implements ModelVariantProvider, Function<ResourceManager, ModelVariantProvider> {
+    public static ItemOBJLoader INSTANCE = new ItemOBJLoader();
     public static final Gson GSON = (new GsonBuilder())
-            .registerTypeAdapter (ModelTransformation.class, new JsonOBJLoader.ModelTransformDeserializer())
-            .registerTypeAdapter (Transformation.class, new JsonOBJLoader.TransformDeserializer())
+            .registerTypeAdapter (ModelTransformation.class, new ItemOBJLoader.ModelTransformDeserializer())
+            .registerTypeAdapter (Transformation.class, new ItemOBJLoader.TransformDeserializer())
             .create ();
     private static final OBJLoader OBJ_LOADER = OBJLoader.INSTANCE;
 

--- a/src/main/java/nerdhub/foml/obj/JsonOBJLoader.java
+++ b/src/main/java/nerdhub/foml/obj/JsonOBJLoader.java
@@ -1,0 +1,89 @@
+package nerdhub.foml.obj;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonObject;
+import nerdhub.foml.FOML;
+import nerdhub.foml.obj.baked.OBJUnbakedModel;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.fabricmc.fabric.api.client.model.ModelProviderContext;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.render.model.UnbakedModel;
+import net.minecraft.client.render.model.json.ModelTransformation;
+import net.minecraft.client.render.model.json.Transformation;
+import net.minecraft.resource.ResourceManager;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.JsonHelper;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+
+/***
+ *  JsonOBJLoader
+ *  Child class of the OBJ loader that loads basic item OBJ models with JSON model transformations.
+ *
+ *  Created by jard at 2:27 AM on September 22, 2019.
+ ***/
+public class JsonOBJLoader extends OBJLoader {
+    public static final JsonOBJLoader INSTANCE = new JsonOBJLoader();
+    public static final Gson GSON = (new GsonBuilder())
+            .registerTypeAdapter (ModelTransformation.class, new ModelTransformDeserializer ())
+            .registerTypeAdapter (Transformation.class, new TransformDeserializer ())
+            .create ();
+
+    @Override
+    public UnbakedModel loadModelResource(Identifier identifier, ModelProviderContext modelProviderContext) {
+        if(OBJLoader.INSTANCE.isRegistered(identifier.getNamespace())) {
+            ResourceManager resourceManager = MinecraftClient.getInstance().getResourceManager();
+
+            Identifier modelPath = new Identifier (identifier.getNamespace (),
+                    "models/" + identifier.getPath () + ".obj-json");
+
+            try (Reader reader = new InputStreamReader(resourceManager.getResource(modelPath).getInputStream())) {
+                JsonObject rawModel = JsonHelper.deserialize (reader);
+
+                String objPath = rawModel.get ("parent").getAsString ();
+                if (! objPath.endsWith (".obj"))
+                    throw new IOException ("Parent of JsonOBJ model must be a .obj file.");
+
+                Identifier parentPath = new Identifier (objPath);
+
+                ModelTransformation transformation = null;
+                if (rawModel.has ("display")) {
+                    JsonObject rawTransform = JsonHelper.getObject (rawModel, "display");
+                    transformation = GSON.fromJson (rawTransform, ModelTransformation.class);
+                }
+
+                return (OBJUnbakedModel) OBJLoader.INSTANCE.loadModelResource (parentPath,
+                        modelProviderContext, transformation);
+            } catch (IOException e) {
+                // Silently ignore filenotfoundexceptions, as all models in a registered namespace would otherwise
+                // spew the console with errors
+                if (! (e instanceof FileNotFoundException)) {
+                    FOML.LOGGER.error("Unable to load OBJ Model, Source: " + identifier.toString(), e);
+                }
+            }
+
+            if (identifier.getPath ().endsWith (".obj-json")) {
+                System.out.println ("Test 2");
+            }
+        }
+        return null;
+    }
+
+    @Environment(EnvType.CLIENT)
+    public static class ModelTransformDeserializer extends ModelTransformation.Deserializer {
+        protected ModelTransformDeserializer () {
+            super ();
+        }
+    }
+    @Environment(EnvType.CLIENT)
+    public static class TransformDeserializer extends Transformation.Deserializer {
+        protected TransformDeserializer () {
+            super ();
+        }
+    }
+}

--- a/src/main/java/nerdhub/foml/obj/JsonOBJLoader.java
+++ b/src/main/java/nerdhub/foml/obj/JsonOBJLoader.java
@@ -66,10 +66,6 @@ public class JsonOBJLoader extends OBJLoader {
                     FOML.LOGGER.error("Unable to load OBJ Model, Source: " + identifier.toString(), e);
                 }
             }
-
-            if (identifier.getPath ().endsWith (".obj-json")) {
-                System.out.println ("Test 2");
-            }
         }
         return null;
     }

--- a/src/main/java/nerdhub/foml/obj/OBJLoader.java
+++ b/src/main/java/nerdhub/foml/obj/OBJLoader.java
@@ -57,7 +57,7 @@ public class OBJLoader implements ModelResourceProvider, Function<ResourceManage
             Identifier resourceId = new Identifier(modid, "models/" + name);
             // Use 1.0.0 MTL path as a fallback
             if (!manager.containsResource(resourceId)) {
-                resourceId = new Identifier(modid, "models/block" + name);
+                resourceId = new Identifier(modid, "models/block/" + name);
             }
 
             // Continue with normal resource loading code

--- a/src/main/java/nerdhub/foml/obj/OBJLoader.java
+++ b/src/main/java/nerdhub/foml/obj/OBJLoader.java
@@ -55,6 +55,12 @@ public class OBJLoader implements ModelResourceProvider, Function<ResourceManage
 
         for (String name : mtlNames) {
             Identifier resourceId = new Identifier(modid, "models/" + name);
+            // Use 1.0.0 MTL path as a fallback
+            if (!manager.containsResource(resourceId)) {
+                resourceId = new Identifier(modid, "models/block" + name);
+            }
+
+            // Continue with normal resource loading code
             if(manager.containsResource(resourceId)) {
                 Resource resource = manager.getResource(resourceId);
                 mtls.addAll(MtlReader.read(resource.getInputStream()));

--- a/src/main/java/nerdhub/foml/obj/baked/OBJBakedModel.java
+++ b/src/main/java/nerdhub/foml/obj/baked/OBJBakedModel.java
@@ -25,9 +25,11 @@ import java.util.function.Supplier;
 public class OBJBakedModel implements BakedModel, FabricBakedModel {
 
     private Mesh mesh;
+    private ModelTransformation transformation;
 
-    public OBJBakedModel(OBJBuilder builder) {
+    public OBJBakedModel(OBJBuilder builder, ModelTransformation transformation) {
         this.mesh = builder.build();
+        this.transformation = transformation;
     }
 
     @Override
@@ -72,7 +74,7 @@ public class OBJBakedModel implements BakedModel, FabricBakedModel {
 
     @Override
     public ModelTransformation getTransformation() {
-        return ModelTransformation.NONE;
+        return transformation;
     }
 
     @Override

--- a/src/main/java/nerdhub/foml/obj/baked/OBJUnbakedModel.java
+++ b/src/main/java/nerdhub/foml/obj/baked/OBJUnbakedModel.java
@@ -5,6 +5,7 @@ import net.minecraft.client.render.model.BakedModel;
 import net.minecraft.client.render.model.ModelBakeSettings;
 import net.minecraft.client.render.model.ModelLoader;
 import net.minecraft.client.render.model.UnbakedModel;
+import net.minecraft.client.render.model.json.ModelTransformation;
 import net.minecraft.client.texture.Sprite;
 import net.minecraft.util.Identifier;
 
@@ -12,11 +13,16 @@ import java.util.*;
 import java.util.function.Function;
 
 public class OBJUnbakedModel implements UnbakedModel {
+    protected OBJBuilder builder;
+    protected ModelTransformation transform;
 
-    private OBJBuilder builder;
+    public OBJUnbakedModel(OBJBuilder builder, ModelTransformation transform) {
+        if (transform == null)
+            transform = ModelTransformation.NONE;
 
-    public OBJUnbakedModel(OBJBuilder builder) {
         this.builder = builder;
+        this.transform = transform;
+
     }
 
     @Override
@@ -34,6 +40,6 @@ public class OBJUnbakedModel implements UnbakedModel {
 
     @Override
     public BakedModel bake(ModelLoader var1, Function<Identifier, Sprite> var2, ModelBakeSettings var3) {
-        return new OBJBakedModel(builder);
+        return new OBJBakedModel(builder, transform);
     }
 }


### PR DESCRIPTION
This PR adds basic backwards-compatible item OBJ model loading support by introducing a new `JsonOBJLoader` to load `.obj-json` models. This new model format is similar to a typical vanilla `.json` model, except that the `parent` element points to an OBJ model in the same way that blockstates would. So far, only item model transformations are supported.

![alt text](https://i.imgur.com/nylMRFm.png "Demonstration of item OBJ models and backwards compatibility with the 1.0.0 blast furnace model")

I chose to use a new format instead of `.json` because it looks like Minecraft will ignore all `ModelResourceProvider`s if it finds a `.json` file and only load that file as a vanilla model. I did not want to mixin the model loading code for this special case and potentially break existing vanilla behavior, so opting for a `.obj-json` file was a cleaner and more robust implementation. The actual extension of the model isn't final yet, though I feel ".obj-json" conveys the fact that the file is formatted as JSON but has some special OBJ stuff to it. =)   

I've also made some other small changes and bug fixes:

Firstly, the `OBJLoader` code did not handle loading triangles properly - since `QuadEmitter`s seem to have a hardcoded four-vertex limit, if `OBJLoader` loaded a model with triangles it would implicitly introduce a fourth vertex at the model's origin, resulting in very glitchy models. This fix was simple: for any detected triangle we simply add a fourth vertex with the same properties as the third. 

Secondly, in `OBJBuilder`, there were some `QuadEmitter` calls that were invoked on a per-vertex basis when they appeared to operate on quads. For instance, ``spriteBake`` was called in the inner vertex loop that populates the `QuadEmitter` with vertex data, and ``spriteUnitSquare(0)`` was invoked despite these values needing to be written with the proper UV coordinates. This resulted in distorted/zoomed out textures when loading in my item OBJ model. So, I just moved these calls out of that loop to right before the `emit()` call. This appears to work for both my mod's item model as well as the existing test models.

Lastly, there was a hardcoded path that made `OBJLoader` look in `models/block/` for MTL models. Obviously this would be a problem with item OBJ models as modders would need to (un-intuitively) insert the files into the block folder, even though they should belong in the item folder. I've removed this hardcoded path in favor of just looking in `models/`, but provided `models/block/` as a fallback for 1.0.0-compatibility. 